### PR TITLE
Fix Bid creation missing auction link

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -30,7 +30,7 @@ export function getOrCreateBid(
     bid.bidder = bidder;
     bid.amount = bidAmount;
     bid.auctionID = BigInt.fromString(auction.id);
-    // bid.auction = auction.id;
+    bid.auction = auction.id;
     bid.outbid = false;
     bid.bidTime = event.block.timestamp;
     bid.claimed = false;


### PR DESCRIPTION
## Summary
- link `Bid` entities to their parent `Auction`

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6885be9dda4c83259fc76f5bec051cda